### PR TITLE
Refresh darkness visual & Tweak-easy colour scheme & Fixes

### DIFF
--- a/dark.css
+++ b/dark.css
@@ -1,14 +1,14 @@
 :root {
-  --darkhx-l0: #212121;
-  --darkhx-l1: #2f2f2f;
-  --darkhx-l2: #353535;
-  --darkhx-l3: #373737;
-  --darkhx-l4: #474747;
-  --darkhx-l5: #575757;
-  --darkhx-l6: #8b8b8b;
-  --darkhx-l7: #c8c8c8;
-  --darkhx-l8: #eee;
-  --darkhx-l9: #fff;
+  --darkhx-l0: #0c0d0f;
+  --darkhx-l1: #1e1f20;
+  --darkhx-l2: #2f3031;
+  --darkhx-l3: #414244;
+  --darkhx-l4: #545556;
+  --darkhx-l5: #68686a;
+  --darkhx-l6: #7c7d7f;
+  --darkhx-l7: #919293;
+  --darkhx-l8: #a6a7a9;
+  --darkhx-l9: #bcbdbf;
   
 }
 

--- a/dark.css
+++ b/dark.css
@@ -1,109 +1,125 @@
-html.dark {
+:root {
+  --darkhx-l0: #212121;
+  --darkhx-l1: #2f2f2f;
+  --darkhx-l2: #353535;
+  --darkhx-l3: #373737;
+  --darkhx-l4: #474747;
+  --darkhx-l5: #575757;
+  --darkhx-l6: #8b8b8b;
+  --darkhx-l7: #c8c8c8;
+  --darkhx-l8: #eee;
+  --darkhx-l9: #fff;
+  
+}
+
+
+
+html {
   background: gray;
 }
 
-html.dark #main-content {
-  background: none repeat scroll 0 0 #212121;
+html #main-content {
+  background: none repeat scroll 0 0 var(--darkhx-l0);
 }
 
-html.dark #top-bar,
-html.dark .body-wrap,
-html.dark #main-nav ul ul,
-html.dark #main-nav ul li,
-html.dark .dropdown-menu {
-  background: #2f2f2f;
+html #top-bar,
+html .body-wrap,
+html #main-nav ul ul,
+html #main-nav ul li,
+html .dropdown-menu {
+  background: var(--darkhx-l1);
 }
 
-html.dark #breadcrumb,
-html.dark #top-announce,
-html.dark #post-header {
-  background: #373737;
+html #breadcrumb,
+html #top-announce,
+html #post-header {
+  background: var(--darkhx-l3);
   border-bottom: none;
-  color: rgb(200, 200, 200);
+  color: var(--darkhx-l7);
 }
 
-html.dark #breadcrumb a,
-html.dark #top-announce a,
-html.dark #post-header a {
-  color: rgb(200, 200, 200);
+html #breadcrumb a,
+html #top-announce a,
+html #post-header a {
+  color: var(--darkhx-l7);
 }
 
-html.dark .widget-content,
-html.dark .archive-thumb h2,
-html.dark #archive-head,
-html.dark .widget-title,
-html.dark .su-spoiler-style-fancy {
-  background: #2f2f2f !important;
-  color: rgb(200, 200, 200);
+html .widget-content,
+html .archive-thumb h2,
+html #archive-head,
+html .widget-title,
+html .su-spoiler-style-fancy {
+  background: var(--darkhx-l1) !important;
+  color: var(--darkhx-l7);
 }
 
-html.dark .widget-content a {
-  color: rgb(200, 200, 200);
+html .widget-content a {
+  color: var(--darkhx-l7);
 }
 
-html.dark .page-nav a {
-  color: rgb(200, 200, 200);
-  background: #2f2f2f;
+html .page-nav a {
+  color: var(--darkhx-l7);
+  background: var(--darkhx-l1);
 }
 
-html.dark article .more-link {
-  color: rgb(200, 200, 200) !important;
+html article .more-link {
+  color: var(--darkhx-l7) !important;
 }
 
-html.dark input.jump-page {
-  background: #575757;
+html input.jump-page {
+  background: var(--darkhx-l5);
   margin-top: 2px;
   width: 30px;
-  -webkit-text-fill-color: rgb(200, 200, 200);
+  -webkit-text-fill-color: var(--darkhx-l7);
 }
 
-html.dark .su-spoiler-title,
-html.dark .entry table,
-html.dark .entry table td,
-html.dark .sc_act,
-html.dark .su-box-content,
-html.dark blockquote {
-  background: #575757;
-  color: rgb(200, 200, 200);
+html .su-spoiler-title,
+html .entry table,
+html .entry table td,
+html .sc_act,
+html .su-box-content,
+html blockquote {
+  background: var(--darkhx-l5);
+  color: var(--darkhx-l7);
 }
 
-html.dark .sc_act:hover {
+html .sc_act:hover {
   background: #8b8b8b;
 }
 
-html.dark .su-spoiler-content {
-  background: #474747;
+html .su-spoiler-content {
+  background: var(--darkhx-l4);
   display: flex;
   flex-direction: column;
   gap: 10px;
 }
 
-html.dark .entry img {
+html .entry img {
   border: none;
   background: none;
 }
 
-html.dark .dlbox,
-html.dark #author-box h3,
-html.dark #related-posts h3,
-html.dark #comments h3,
-html.dark #commentform textarea,
-html.dark .searchform div input,
-html.dark .user-center {
-  background: #474747;
+html .dlbox,
+html #author-box h3,
+html #related-posts h3,
+html #comments h3,
+html #commentform textarea,
+html .searchform div input,
+html .user-center {
+  background: var(--darkhx-l4);
 }
 
-html.dark .dlbox .dlbox-title,
-html.dark #author-box .author-info,
-html.dark .comment-body,
-html.dark .commentlist .comment,
-html.dark .comment-form,
-html.dark #submit-bt,
-html.dark #user-menu li {
-  background: #353535 !important;
+html .dlbox .dlbox-title,
+html #author-box .author-info,
+html .comment-body,
+html .commentlist .comment,
+html .comment-form,
+html #submit-bt,
+html #user-menu li {
+  background: var(--darkhx-l2) !important;
 }
 
-html.dark #commentform textarea,
-html.dark #submit-bt {
-  -webkit-text-fill-color: rgb(200, 200, 200);
+html #commentform textarea,
+html #submit-bt {
+  -webkit-text-fill-color: var(--darkhx-l7);
 }

--- a/dark.css
+++ b/dark.css
@@ -14,94 +14,94 @@
 
 
 /* level 0 */
-html {
+html.dark {
   background: var(--darkhx-l0);
 }
 
-html #main-content {
+html.dark #main-content {
   background: none repeat scroll 0 0 var(--darkhx-l0);
 }
 
 
-html #top-bar,
-html .body-wrap,
-html #main-nav ul ul,
-html #main-nav ul li,
-html .dropdown-menu,
-html .footer-info {
+html.dark #top-bar,
+html.dark .body-wrap,
+html.dark #main-nav ul ul,
+html.dark #main-nav ul li,
+html.dark .dropdown-menu,
+html.dark .footer-info {
   background: var(--darkhx-l1);
 }
 
-html #breadcrumb,
-html #top-announce,
-html #post-header {
+html.dark #breadcrumb,
+html.dark #top-announce,
+html.dark #post-header {
   background: var(--darkhx-l2);
   border-bottom: none;
   color: var(--darkhx-l8);
 }
 
-html #breadcrumb a,
-html #top-announce a,
-html #post-header a {
+html.dark #breadcrumb a,
+html.dark #top-announce a,
+html.dark #post-header a {
   color: var(--darkhx-l8);
 }
 
 /* article flow items */
-html .widget-content,
-html .archive-thumb h2,
-html #archive-head,
-html .widget-title,
-html .su-spoiler-style-fancy {
+html.dark .widget-content,
+html.dark .archive-thumb h2,
+html.dark #archive-head,
+html.dark .widget-title,
+html.dark .su-spoiler-style-fancy {
   background: var(--darkhx-l1) !important;
   color: var(--darkhx-l8);
 }
 
-html .widget-content a {
+html.dark .widget-content a {
   color: var(--darkhx-l9);
 }
 
-html .archive-list li:hover h2 a {
+html.dark .archive-list li:hover h2 a {
   color: var(--darkhx-accent-0);
 }
 
 /* page navigation */
-html .page-nav a {
+html.dark .page-nav a {
   color: var(--darkhx-l9);
   background: var(--darkhx-l1);
 }
 
-html article .more-link {
+html.dark article .more-link {
   color: var(--darkhx-l1) !important;
   font-weight: 600;
 }
 
-html input.jump-page {
+html.dark input.jump-page {
   background: var(--darkhx-l0);
   margin-top: 2px;
   width: 30px;
   -webkit-text-fill-color: var(--darkhx-l9);
 }
 
-html .su-spoiler-title,
-html .entry table,
-html .entry table td,
-html .sc_act,
-html .su-box-content,
-html blockquote {
+html.dark .su-spoiler-title,
+html.dark .entry table,
+html.dark .entry table td,
+html.dark .sc_act,
+html.dark .su-box-content,
+html.dark blockquote {
   background: var(--darkhx-l5);
   color: var(--darkhx-l7);
 }
 
-html .sc_act:hover {
+html.dark .sc_act:hover {
   background: #8b8b8b;
 }
 
 /* spoiler */
-html .su-spoiler-style-fancy > .su-spoiler-title {
+html.dark .su-spoiler-style-fancy > .su-spoiler-title {
   background: var(--darkhx-l2);
 }
 
-html .su-spoiler-content {
+html.dark .su-spoiler-content {
   background: var(--darkhx-l4);
   display: flex;
   flex-direction: column;
@@ -109,43 +109,43 @@ html .su-spoiler-content {
 }
 
 /* article page */
-html .entry p,
-html .entry strong {
+html.dark .entry p,
+html.dark .entry strong {
   color: var(--darkhx-l9);
 }
 
-html .entry img {
+html.dark .entry img {
   border-color: var(--darkhx-l3);
   background: none;
 }
 
-html .dlbox .dlbox-title {
+html.dark .dlbox .dlbox-title {
   color: var(--darkhx-l8);
   background: var(--darkhx-l2);
 }
 
-html #author-box h3,
-html #related-posts h3,
-html #comments h3,
-html #commentform textarea,
-html .searchform div input,
-html .user-center,
-html .post-toolbar-report,
-html .box-title span {
+html.dark #author-box h3,
+html.dark #related-posts h3,
+html.dark #comments h3,
+html.dark #commentform textarea,
+html.dark .searchform div input,
+html.dark .user-center,
+html.dark .post-toolbar-report,
+html.dark .box-title span {
   background: var(--darkhx-l2);
 }
 
-html .dlbox,
-html #author-box .author-info,
-html .comment-body,
-html .commentlist .comment,
-html .comment-form,
-html #submit-bt,
-html #user-menu li {
+html.dark .dlbox,
+html.dark #author-box .author-info,
+html.dark .comment-body,
+html.dark .commentlist .comment,
+html.dark .comment-form,
+html.dark #submit-bt,
+html.dark #user-menu li {
   background: var(--darkhx-l1) !important;
 }
 
-html #commentform textarea,
-html #submit-bt {
+html.dark #commentform textarea,
+html.dark #submit-bt {
   -webkit-text-fill-color: var(--darkhx-l7);
 }

--- a/dark.css
+++ b/dark.css
@@ -9,143 +9,258 @@
   --darkhx-l7: #919293;
   --darkhx-l8: #a6a7a9;
   --darkhx-l9: #bcbdbf;
-  --darkhx-accent-0: #a7f0d7;
+  --darkhx-accent-0: #09B1B9;
 }
 
 
 /* level 0 */
-html.dark {
+html {
   background: var(--darkhx-l0);
 }
 
-html.dark #main-content {
+html #main-content {
   background: none repeat scroll 0 0 var(--darkhx-l0);
 }
 
 
-html.dark #top-bar,
-html.dark .body-wrap,
-html.dark #main-nav ul ul,
-html.dark #main-nav ul li,
-html.dark .dropdown-menu,
-html.dark .footer-info {
+html #top-bar,
+html .body-wrap,
+html #main-nav ul ul,
+html #main-nav ul li,
+html .dropdown-menu,
+html .footer-info {
   background: var(--darkhx-l1);
 }
 
-html.dark #breadcrumb,
-html.dark #top-announce,
-html.dark #post-header {
+html #main-nav > ul > li.current-menu-ancestor::after, #main-nav > ul > li.current-menu-item::after, #main-nav > ul > li.current-menu-parent::after, #main-nav > ul > li.current-post-ancestor::after {
+  border-color: transparent var(--darkhx-l0) transparent transparent;
+}
+
+html #breadcrumb,
+html #top-announce,
+html #post-header {
   background: var(--darkhx-l2);
   border-bottom: none;
   color: var(--darkhx-l8);
 }
 
-html.dark #breadcrumb a,
-html.dark #top-announce a,
-html.dark #post-header a {
+html #breadcrumb a,
+html #top-announce a,
+html #post-header a {
   color: var(--darkhx-l8);
 }
 
 /* article flow items */
-html.dark .widget-content,
-html.dark .archive-thumb h2,
-html.dark #archive-head,
-html.dark .widget-title,
-html.dark .su-spoiler-style-fancy {
+html .widget-content,
+html .archive-thumb h2,
+html #archive-head,
+html .widget-title,
+html .widget-title h3,
+html .su-spoiler-style-fancy {
   background: var(--darkhx-l1) !important;
-  color: var(--darkhx-l8);
+  color: var(--darkhx-l7);
 }
 
-html.dark .widget-content a {
+html .widget-content a {
   color: var(--darkhx-l9);
 }
 
-html.dark .archive-list li:hover h2 a {
+html .archive-list li:hover h2 a {
   color: var(--darkhx-accent-0);
 }
 
 /* page navigation */
-html.dark .page-nav a {
+html .page-nav a {
   color: var(--darkhx-l9);
   background: var(--darkhx-l1);
 }
 
-html.dark article .more-link {
+html article .more-link {
   color: var(--darkhx-l1) !important;
   font-weight: 600;
 }
 
-html.dark input.jump-page {
+html input.jump-page {
   background: var(--darkhx-l0);
   margin-top: 2px;
   width: 30px;
   -webkit-text-fill-color: var(--darkhx-l9);
 }
 
-html.dark .su-spoiler-title,
-html.dark .entry table,
-html.dark .entry table td,
-html.dark .sc_act,
-html.dark .su-box-content,
-html.dark blockquote {
+html .su-spoiler-title,
+html .entry table,
+html .entry table td,
+html .sc_act,
+html blockquote {
+  background: var(--darkhx-l0);
+  color: var(--darkhx-l8);
+}
+
+html .sc_act:hover {
   background: var(--darkhx-l5);
-  color: var(--darkhx-l7);
 }
 
-html.dark .sc_act:hover {
-  background: #8b8b8b;
+html .navbar .nav > li > .dropdown-menu::after {
+	border-bottom: 6px solid var(--darkhx-l1);
 }
 
-/* spoiler */
-html.dark .su-spoiler-style-fancy > .su-spoiler-title {
-  background: var(--darkhx-l2);
-}
-
-html.dark .su-spoiler-content {
-  background: var(--darkhx-l4);
-  display: flex;
-  flex-direction: column;
-  gap: 10px;
-}
-
-/* article page */
-html.dark .entry p,
-html.dark .entry strong {
+html .searchform div input {
   color: var(--darkhx-l9);
 }
 
-html.dark .entry img {
+/* article page */
+html .su-service-title,
+html .entry p,
+html .entry strong {
+  color: var(--darkhx-l9);
+}
+
+html .entry,
+html .entry h1,
+html .entry h2,
+html .entry h3 {
+  color: var(--darkhx-l8);
+}
+
+html .entry img {
   border-color: var(--darkhx-l3);
   background: none;
 }
 
-html.dark .dlbox .dlbox-title {
+html [class*="markup--"] {
+  color: var(--darkhx-l7) !important;
+}
+
+html .entry th {
+  background: var(--darkhx-l2);
+}
+
+/* spoiler */
+html .su-spoiler-style-fancy > .su-spoiler-title {
+  background: var(--darkhx-l2);
+}
+
+html .su-spoiler-content {
+  background: var(--darkhx-l0);
+/*  display: flex;
+  flex-direction: column;
+  gap: 10px; */
+}
+
+html .su-box-content {
+  background: var(--darkhx-l0);
+  color: var(--darkhx-l9);
+}
+
+
+html .entry .wp-caption {
+  background: var(--darkhx-l2);
+}
+
+html .dlbox .dlbox-title {
   color: var(--darkhx-l8);
   background: var(--darkhx-l2);
 }
 
-html.dark #author-box h3,
-html.dark #related-posts h3,
-html.dark #comments h3,
-html.dark #commentform textarea,
-html.dark .searchform div input,
-html.dark .user-center,
-html.dark .post-toolbar-report,
-html.dark .box-title span {
+/* favicon of baidu-pan links */
+html .dlbox p.dlbox-links a[href*="pan.baidu.com/s/"] {
+  color: var(--darkhx-l3);
+  filter: invert(100%);
+}
+
+html .quicktags-toolbar input{
+  color: var(--darkhx-l8);
+  background: var(--darkhx-l1);
+  border-radius: 2px;
+}
+
+html .quicktags-toolbar input:hover {
+  color: var(--darkhx-l9) !important;
+  background: var(--darkhx-l5);
+}
+
+/* 163 music player embed */
+html .aplayer {
+  background: var(--darkhx-l0);
+}
+
+html .aplayer .aplayer-lrc::before,
+html .aplayer .aplayer-lrc::after {
+  background: linear-gradient(180deg,hsla(0,0%,0%,0) 0, hsla(0,0%,0%,.8));
+}
+
+html .aplayer .aplayer-info .aplayer-controller .aplayer-bar-wrap .aplayer-bar {
+  background: var(--darkhx-l3) !important;
+}
+
+
+html .commentlist a:hover {
+  color: var(--darkhx-accent-0);
+}
+
+html #author-box h3,
+html #related-posts h3,
+html #comments h3,
+html #commentform textarea,
+html .searchform div input,
+html .user-center,
+html .post-toolbar-report,
+html .box-title span {
   background: var(--darkhx-l2);
 }
 
-html.dark .dlbox,
-html.dark #author-box .author-info,
-html.dark .comment-body,
-html.dark .commentlist .comment,
-html.dark .comment-form,
-html.dark #submit-bt,
-html.dark #user-menu li {
+html .dlbox,
+html #author-box .author-info,
+html .comment-body,
+html .commentlist .comment,
+html .comment-form,
+html #submit-bt,
+html #user-menu li {
   background: var(--darkhx-l1) !important;
 }
 
-html.dark #commentform textarea,
-html.dark #submit-bt {
+html textarea#comment {
+  font-weight: 600;
+}
+
+html #commentform textarea,
+html #submit-bt {
   -webkit-text-fill-color: var(--darkhx-l7);
+}
+
+
+/* user centre */
+html #user-menu a,
+html .user-avatar p {
+  color: var(--darkhx-l9);
+}
+
+html #user-menu a:hover {
+  color: var(--darkhx-accent-0);
+}
+
+html #fep-menu .fep-button, .fep-button-active {
+  background: var(--darkhx-l1);
+  color: var(--darkhx-l8) !important;
+}
+
+html #fep-menu .fep-button, .fep-button-active:hover,
+html #fep-menu .fep-button, .fep-button-active:active {
+  background: var(--darkhx-l2) !important;
+}
+
+html .footer-nav ul {
+  background: var(--darkhx-l2);
+  transition: background 0.2s ease-out;
+}
+
+html .footer-nav ul:hover {
+  background: var(--darkhx-accent-0);
+  transition: background 0.1s ease-in;
+}
+
+/* ranking page */
+html #ranking-item select {
+  background: var(--darkhx-l0);
+  color: var(--darkhx-l9);
 }

--- a/dark.css
+++ b/dark.css
@@ -119,7 +119,11 @@ html .entry img {
   background: none;
 }
 
-html .dlbox .dlbox-title,
+html .dlbox .dlbox-title {
+  color: var(--darkhx-l8);
+  background: var(--darkhx-l2);
+}
+
 html #author-box h3,
 html #related-posts h3,
 html #comments h3,

--- a/dark.css
+++ b/dark.css
@@ -264,3 +264,23 @@ html #ranking-item select {
   background: var(--darkhx-l0);
   color: var(--darkhx-l9);
 }
+
+/* color palttle replacment */
+html [color="#351755"],
+html [style*='color:#351755'],
+html [style*='color: #351755']{
+  color: #6e40a0 !important;
+}
+
+html [color="#3812b1"],
+html [style*='color:#3812b1'],
+html [style*='color: #3812b1']{
+  color: #552ade !important;
+}
+
+html [color="#000080"],
+html [style*='color:#000080'],
+html [style*='color: #000080']{
+  color: #164cff !important;
+}
+

--- a/dark.css
+++ b/dark.css
@@ -14,281 +14,281 @@
 
 
 /* level 0 */
-html {
+html.dark {
   background: var(--darkhx-l0);
 }
 
-html #main-content {
+html.dark #main-content {
   background: none repeat scroll 0 0 var(--darkhx-l0);
 }
 
 
-html #top-bar,
-html .body-wrap,
-html #main-nav ul ul,
-html #main-nav ul li,
-html .dropdown-menu,
-html .footer-info {
+html.dark #top-bar,
+html.dark .body-wrap,
+html.dark #main-nav ul ul,
+html.dark #main-nav ul li,
+html.dark .dropdown-menu,
+html.dark .footer-info {
   background: var(--darkhx-l1);
 }
 
-html #main-nav > ul > li.current-menu-ancestor::after, #main-nav > ul > li.current-menu-item::after, #main-nav > ul > li.current-menu-parent::after, #main-nav > ul > li.current-post-ancestor::after {
+html.dark #main-nav > ul > li.current-menu-ancestor::after, #main-nav > ul > li.current-menu-item::after, #main-nav > ul > li.current-menu-parent::after, #main-nav > ul > li.current-post-ancestor::after {
   border-color: transparent var(--darkhx-l0) transparent transparent;
 }
 
-html #breadcrumb,
-html #top-announce,
-html #post-header {
+html.dark #breadcrumb,
+html.dark #top-announce,
+html.dark #post-header {
   background: var(--darkhx-l2);
   border-bottom: none;
   color: var(--darkhx-l8);
 }
 
-html #breadcrumb a,
-html #top-announce a,
-html #post-header a {
+html.dark #breadcrumb a,
+html.dark #top-announce a,
+html.dark #post-header a {
   color: var(--darkhx-l8);
 }
 
 /* article flow items */
-html .widget-content,
-html .archive-thumb h2,
-html #archive-head,
-html .widget-title,
-html .widget-title h3,
-html .su-spoiler-style-fancy {
+html.dark .widget-content,
+html.dark .archive-thumb h2,
+html.dark #archive-head,
+html.dark .widget-title,
+html.dark .widget-title h3,
+html.dark .su-spoiler-style-fancy {
   background: var(--darkhx-l1) !important;
   color: var(--darkhx-l7);
 }
 
-html .widget-content a {
+html.dark .widget-content a {
   color: var(--darkhx-l9);
 }
 
-html .archive-list li:hover h2 a {
+html.dark .archive-list li:hover h2 a {
   color: var(--darkhx-accent-0);
 }
 
 /* page navigation */
-html .page-nav a {
+html.dark .page-nav a {
   color: var(--darkhx-l9);
   background: var(--darkhx-l1);
 }
 
-html article .more-link {
+html.dark article .more-link {
   color: var(--darkhx-l1) !important;
   font-weight: 600;
 }
 
-html input.jump-page {
+html.dark input.jump-page {
   background: var(--darkhx-l0);
   margin-top: 2px;
   width: 30px;
   -webkit-text-fill-color: var(--darkhx-l9);
 }
 
-html .su-spoiler-title,
-html .entry table,
-html .entry table td,
-html .sc_act,
-html blockquote {
+html.dark .su-spoiler-title,
+html.dark .entry table,
+html.dark .entry table td,
+html.dark .sc_act,
+html.dark blockquote {
   background: var(--darkhx-l0);
   color: var(--darkhx-l8);
 }
 
-html .sc_act:hover {
+html.dark .sc_act:hover {
   background: var(--darkhx-l5);
 }
 
-html .navbar .nav > li > .dropdown-menu::after {
+html.dark .navbar .nav > li > .dropdown-menu::after {
 	border-bottom: 6px solid var(--darkhx-l1);
 }
 
-html .searchform div input {
+html.dark .searchform div input {
   color: var(--darkhx-l9);
 }
 
 /* article page */
-html .su-service-title,
-html .entry p,
-html .entry strong {
+html.dark .su-service-title,
+html.dark .entry p,
+html.dark .entry strong {
   color: var(--darkhx-l9);
 }
 
-html .entry,
-html .entry h1,
-html .entry h2,
-html .entry h3 {
+html.dark .entry,
+html.dark .entry h1,
+html.dark .entry h2,
+html.dark .entry h3 {
   color: var(--darkhx-l8);
 }
 
-html .entry img {
+html.dark .entry img {
   border-color: var(--darkhx-l3);
   background: none;
 }
 
-html [class*="markup--"] {
+html.dark [class*="markup--"] {
   color: var(--darkhx-l7) !important;
 }
 
-html .entry th {
+html.dark .entry th {
   background: var(--darkhx-l2);
 }
 
 /* spoiler */
-html .su-spoiler-style-fancy > .su-spoiler-title {
+html.dark .su-spoiler-style-fancy > .su-spoiler-title {
   background: var(--darkhx-l2);
 }
 
-html .su-spoiler-content {
+html.dark .su-spoiler-content {
   background: var(--darkhx-l0);
 /*  display: flex;
   flex-direction: column;
   gap: 10px; */
 }
 
-html .su-box-content {
+html.dark .su-box-content {
   background: var(--darkhx-l0);
   color: var(--darkhx-l9);
 }
 
 
-html .entry .wp-caption {
+html.dark .entry .wp-caption {
   background: var(--darkhx-l2);
 }
 
-html .dlbox .dlbox-title {
+html.dark .dlbox .dlbox-title {
   color: var(--darkhx-l8);
   background: var(--darkhx-l2);
 }
 
 /* favicon of baidu-pan links */
-html .dlbox p.dlbox-links a[href*="pan.baidu.com/s/"] {
+html.dark .dlbox p.dlbox-links a[href*="pan.baidu.com/s/"] {
   color: var(--darkhx-l3);
   filter: invert(100%);
 }
 
-html .quicktags-toolbar input{
+html.dark .quicktags-toolbar input{
   color: var(--darkhx-l8);
   background: var(--darkhx-l1);
   border-radius: 2px;
 }
 
-html .quicktags-toolbar input:hover {
+html.dark .quicktags-toolbar input:hover {
   color: var(--darkhx-l9) !important;
   background: var(--darkhx-l5);
 }
 
 /* 163 music player embed */
-html .aplayer {
+html.dark .aplayer {
   background: var(--darkhx-l0);
 }
 
-html .aplayer .aplayer-lrc::before,
-html .aplayer .aplayer-lrc::after {
+html.dark .aplayer .aplayer-lrc::before,
+html.dark .aplayer .aplayer-lrc::after {
   background: linear-gradient(180deg,hsla(0,0%,0%,0) 0, hsla(0,0%,0%,.8));
 }
 
-html .aplayer .aplayer-info .aplayer-controller .aplayer-bar-wrap .aplayer-bar {
+html.dark .aplayer .aplayer-info .aplayer-controller .aplayer-bar-wrap .aplayer-bar {
   background: var(--darkhx-l3) !important;
 }
 
 
-html .commentlist a:hover {
+html.dark .commentlist a:hover {
   color: var(--darkhx-accent-0);
 }
 
-html #author-box h3,
-html #related-posts h3,
-html #comments h3,
-html #commentform textarea,
-html .searchform div input,
-html .user-center,
-html .post-toolbar-report,
-html .box-title span {
+html.dark #author-box h3,
+html.dark #related-posts h3,
+html.dark #comments h3,
+html.dark #commentform textarea,
+html.dark .searchform div input,
+html.dark .user-center,
+html.dark .post-toolbar-report,
+html.dark .box-title span {
   background: var(--darkhx-l2);
 }
 
-html .dlbox,
-html #author-box .author-info,
-html .comment-body,
-html .commentlist .comment,
-html .comment-form,
-html #submit-bt,
-html #user-menu li {
+html.dark .dlbox,
+html.dark #author-box .author-info,
+html.dark .comment-body,
+html.dark .commentlist .comment,
+html.dark .comment-form,
+html.dark #submit-bt,
+html.dark #user-menu li {
   background: var(--darkhx-l1) !important;
 }
 
-html textarea#comment {
+html.dark textarea#comment {
   font-weight: 600;
 }
 
-html #commentform textarea,
-html #submit-bt {
+html.dark #commentform textarea,
+html.dark #submit-bt {
   -webkit-text-fill-color: var(--darkhx-l7);
 }
 
 
 /* user centre */
-html #user-menu a,
-html .user-avatar p {
+html.dark #user-menu a,
+html.dark .user-avatar p {
   color: var(--darkhx-l9);
 }
 
-html #user-menu a:hover {
+html.dark #user-menu a:hover {
   color: var(--darkhx-accent-0);
 }
 
-html #fep-menu .fep-button, .fep-button-active {
+html.dark #fep-menu .fep-button, .fep-button-active {
   background: var(--darkhx-l1);
   color: var(--darkhx-l8) !important;
 }
 
-html #fep-menu .fep-button, .fep-button-active:hover,
-html #fep-menu .fep-button, .fep-button-active:active {
+html.dark #fep-menu .fep-button, .fep-button-active:hover,
+html.dark #fep-menu .fep-button, .fep-button-active:active {
   background: var(--darkhx-l2) !important;
 }
 
-html .footer-nav ul {
+html.dark .footer-nav ul {
   background: var(--darkhx-l2);
   transition: background 0.2s ease-out;
 }
 
-html .footer-nav ul:hover {
+html.dark .footer-nav ul:hover {
   background: var(--darkhx-accent-0);
   transition: background 0.1s ease-in;
 }
 
 /* ranking page */
-html #ranking-item select {
+html.dark #ranking-item select {
   background: var(--darkhx-l0);
   color: var(--darkhx-l9);
 }
 
 /* color palttle replacment */
-html [color="#351755"],
-html [style*='color:#351755'],
-html [style*='color: #351755']{
+html.dark [color="#351755"],
+html.dark [style*='color:#351755'],
+html.dark [style*='color: #351755']{
   color: #6e40a0 !important;
 }
 
-html [color="#3812b1"],
-html [style*='color:#3812b1'],
-html [style*='color: #3812b1']{
+html.dark [color="#3812b1"],
+html.dark [style*='color:#3812b1'],
+html.dark [style*='color: #3812b1']{
   color: #552ade !important;
 }
 
-html [color="#000080"],
-html [style*='color:#000080'],
-html [style*='color: #000080']{
+html.dark [color="#000080"],
+html.dark [style*='color:#000080'],
+html.dark [style*='color: #000080']{
   color: #164cff !important;
 }
 
 /* misc tweaking */
-html .logoimg {
+html.dark .logoimg {
   scale: 83%;
 }
 
-html div[id^="barrage_"] {
+html.dark div[id^="barrage_"] {
   z-index: 99;
 }

--- a/dark.css
+++ b/dark.css
@@ -9,68 +9,77 @@
   --darkhx-l7: #919293;
   --darkhx-l8: #a6a7a9;
   --darkhx-l9: #bcbdbf;
-  
+  --darkhx-accent-0: #a7f0d7;
 }
 
 
-
+/* level 0 */
 html {
-  background: gray;
+  background: var(--darkhx-l0);
 }
 
 html #main-content {
   background: none repeat scroll 0 0 var(--darkhx-l0);
 }
 
+
 html #top-bar,
 html .body-wrap,
 html #main-nav ul ul,
 html #main-nav ul li,
-html .dropdown-menu {
+html .dropdown-menu,
+html .footer-info {
   background: var(--darkhx-l1);
 }
 
 html #breadcrumb,
 html #top-announce,
 html #post-header {
-  background: var(--darkhx-l3);
+  background: var(--darkhx-l2);
   border-bottom: none;
-  color: var(--darkhx-l7);
+  color: var(--darkhx-l8);
 }
 
 html #breadcrumb a,
 html #top-announce a,
 html #post-header a {
-  color: var(--darkhx-l7);
+  color: var(--darkhx-l8);
 }
 
+/* article flow items */
 html .widget-content,
 html .archive-thumb h2,
 html #archive-head,
 html .widget-title,
 html .su-spoiler-style-fancy {
   background: var(--darkhx-l1) !important;
-  color: var(--darkhx-l7);
+  color: var(--darkhx-l8);
 }
 
 html .widget-content a {
-  color: var(--darkhx-l7);
+  color: var(--darkhx-l9);
 }
 
+html .archive-list li:hover h2 a {
+  color: var(--darkhx-accent-0);
+}
+
+/* page navigation */
 html .page-nav a {
-  color: var(--darkhx-l7);
+  color: var(--darkhx-l9);
   background: var(--darkhx-l1);
 }
 
 html article .more-link {
-  color: var(--darkhx-l7) !important;
+  color: var(--darkhx-l1) !important;
+  font-weight: 600;
 }
 
 html input.jump-page {
-  background: var(--darkhx-l5);
+  background: var(--darkhx-l0);
   margin-top: 2px;
   width: 30px;
-  -webkit-text-fill-color: var(--darkhx-l7);
+  -webkit-text-fill-color: var(--darkhx-l9);
 }
 
 html .su-spoiler-title,
@@ -87,6 +96,11 @@ html .sc_act:hover {
   background: #8b8b8b;
 }
 
+/* spoiler */
+html .su-spoiler-style-fancy > .su-spoiler-title {
+  background: var(--darkhx-l2);
+}
+
 html .su-spoiler-content {
   background: var(--darkhx-l4);
   display: flex;
@@ -94,29 +108,37 @@ html .su-spoiler-content {
   gap: 10px;
 }
 
+/* article page */
+html .entry p,
+html .entry strong {
+  color: var(--darkhx-l9);
+}
+
 html .entry img {
-  border: none;
+  border-color: var(--darkhx-l3);
   background: none;
 }
 
-html .dlbox,
+html .dlbox .dlbox-title,
 html #author-box h3,
 html #related-posts h3,
 html #comments h3,
 html #commentform textarea,
 html .searchform div input,
-html .user-center {
-  background: var(--darkhx-l4);
+html .user-center,
+html .post-toolbar-report,
+html .box-title span {
+  background: var(--darkhx-l2);
 }
 
-html .dlbox .dlbox-title,
+html .dlbox,
 html #author-box .author-info,
 html .comment-body,
 html .commentlist .comment,
 html .comment-form,
 html #submit-bt,
 html #user-menu li {
-  background: var(--darkhx-l2) !important;
+  background: var(--darkhx-l1) !important;
 }
 
 html #commentform textarea,

--- a/dark.css
+++ b/dark.css
@@ -284,3 +284,11 @@ html [style*='color: #000080']{
   color: #164cff !important;
 }
 
+/* misc tweaking */
+html .logoimg {
+  scale: 83%;
+}
+
+html div[id^="barrage_"] {
+  z-index: 99;
+}

--- a/index.js
+++ b/index.js
@@ -19,63 +19,88 @@
 
 ;(function () {
   GM_addStyle(`
+:root {
+  --darkhx-l0: #0c0d0f;
+  --darkhx-l1: #1e1f20;
+  --darkhx-l2: #2f3031;
+  --darkhx-l3: #414244;
+  --darkhx-l4: #545556;
+  --darkhx-l5: #68686a;
+  --darkhx-l6: #7c7d7f;
+  --darkhx-l7: #919293;
+  --darkhx-l8: #a6a7a9;
+  --darkhx-l9: #bcbdbf;
+  --darkhx-accent-0: #a7f0d7;
+}
+
+
+/* level 0 */
 html.dark {
-  background: gray;
+  background: var(--darkhx-l0);
 }
 
 html.dark #main-content {
-  background: none repeat scroll 0 0 #212121;
+  background: none repeat scroll 0 0 var(--darkhx-l0);
 }
+
 
 html.dark #top-bar,
 html.dark .body-wrap,
 html.dark #main-nav ul ul,
 html.dark #main-nav ul li,
-html.dark .dropdown-menu {
-  background: #2f2f2f;
+html.dark .dropdown-menu,
+html.dark .footer-info {
+  background: var(--darkhx-l1);
 }
 
 html.dark #breadcrumb,
 html.dark #top-announce,
 html.dark #post-header {
-  background: #373737;
+  background: var(--darkhx-l2);
   border-bottom: none;
-  color: rgb(200, 200, 200);
+  color: var(--darkhx-l8);
 }
 
 html.dark #breadcrumb a,
 html.dark #top-announce a,
 html.dark #post-header a {
-  color: rgb(200, 200, 200);
+  color: var(--darkhx-l8);
 }
 
+/* article flow items */
 html.dark .widget-content,
 html.dark .archive-thumb h2,
 html.dark #archive-head,
 html.dark .widget-title,
 html.dark .su-spoiler-style-fancy {
-  background: #2f2f2f !important;
-  color: rgb(200, 200, 200);
+  background: var(--darkhx-l1) !important;
+  color: var(--darkhx-l8);
 }
 
 html.dark .widget-content a {
-  color: rgb(200, 200, 200);
+  color: var(--darkhx-l9);
 }
 
+html.dark .archive-list li:hover h2 a {
+  color: var(--darkhx-accent-0);
+}
+
+/* page navigation */
 html.dark .page-nav a {
-  color: rgb(200, 200, 200);
-  background: #2f2f2f;
+  color: var(--darkhx-l9);
+  background: var(--darkhx-l1);
 }
 
 html.dark article .more-link {
-  color: rgb(200, 200, 200) !important;
+  color: var(--darkhx-l1) !important;
+  font-weight: 600;
 }
 
 html.dark input.jump-page {
-  background: #575757;
+  background: var(--darkhx-l0);
   margin-top: 2px;
   width: 30px;
-  -webkit-text-fill-color: rgb(200, 200, 200);
+  -webkit-text-fill-color: var(--darkhx-l9);
 }
 
 html.dark .su-spoiler-title,
@@ -84,50 +109,68 @@ html.dark .entry table td,
 html.dark .sc_act,
 html.dark .su-box-content,
 html.dark blockquote {
-  background: #575757;
-  color: rgb(200, 200, 200);
+  background: var(--darkhx-l5);
+  color: var(--darkhx-l7);
 }
 
 html.dark .sc_act:hover {
   background: #8b8b8b;
 }
 
+/* spoiler */
+html.dark .su-spoiler-style-fancy > .su-spoiler-title {
+  background: var(--darkhx-l2);
+}
+
 html.dark .su-spoiler-content {
-  background: #474747;
+  background: var(--darkhx-l4);
   display: flex;
   flex-direction: column;
   gap: 10px;
 }
 
+/* article page */
+html.dark .entry p,
+html.dark .entry strong {
+  color: var(--darkhx-l9);
+}
+
 html.dark .entry img {
-  border: none;
+  border-color: var(--darkhx-l3);
   background: none;
 }
 
-html.dark .dlbox,
+html.dark .dlbox .dlbox-title {
+  color: var(--darkhx-l8);
+  background: var(--darkhx-l2);
+}
+
 html.dark #author-box h3,
 html.dark #related-posts h3,
 html.dark #comments h3,
 html.dark #commentform textarea,
 html.dark .searchform div input,
-html.dark .user-center {
-  background: #474747;
+html.dark .user-center,
+html.dark .post-toolbar-report,
+html.dark .box-title span {
+  background: var(--darkhx-l2);
 }
 
-html.dark .dlbox .dlbox-title,
+html.dark .dlbox,
 html.dark #author-box .author-info,
 html.dark .comment-body,
 html.dark .commentlist .comment,
 html.dark .comment-form,
 html.dark #submit-bt,
 html.dark #user-menu li {
-  background: #353535 !important;
+  background: var(--darkhx-l1) !important;
 }
 
 html.dark #commentform textarea,
 html.dark #submit-bt {
-  -webkit-text-fill-color: rgb(200, 200, 200);
+  -webkit-text-fill-color: var(--darkhx-l7);
 }
+
 `)
 
   GM_registerMenuCommand('跟随系统', () => {

--- a/index.js
+++ b/index.js
@@ -30,11 +30,9 @@
   --darkhx-l7: #919293;
   --darkhx-l8: #a6a7a9;
   --darkhx-l9: #bcbdbf;
-  --darkhx-accent-0: #a7f0d7;
+  --darkhx-accent-0: #09B1B9;
 }
 
-
-/* level 0 */
 html.dark {
   background: var(--darkhx-l0);
 }
@@ -53,6 +51,10 @@ html.dark .footer-info {
   background: var(--darkhx-l1);
 }
 
+html.dark #main-nav > ul > li.current-menu-ancestor::after, #main-nav > ul > li.current-menu-item::after, #main-nav > ul > li.current-menu-parent::after, #main-nav > ul > li.current-post-ancestor::after {
+  border-color: transparent var(--darkhx-l0) transparent transparent;
+}
+
 html.dark #breadcrumb,
 html.dark #top-announce,
 html.dark #post-header {
@@ -67,14 +69,14 @@ html.dark #post-header a {
   color: var(--darkhx-l8);
 }
 
-/* article flow items */
 html.dark .widget-content,
 html.dark .archive-thumb h2,
 html.dark #archive-head,
 html.dark .widget-title,
+html.dark .widget-title h3,
 html.dark .su-spoiler-style-fancy {
   background: var(--darkhx-l1) !important;
-  color: var(--darkhx-l8);
+  color: var(--darkhx-l7);
 }
 
 html.dark .widget-content a {
@@ -85,7 +87,6 @@ html.dark .archive-list li:hover h2 a {
   color: var(--darkhx-accent-0);
 }
 
-/* page navigation */
 html.dark .page-nav a {
   color: var(--darkhx-l9);
   background: var(--darkhx-l1);
@@ -107,32 +108,34 @@ html.dark .su-spoiler-title,
 html.dark .entry table,
 html.dark .entry table td,
 html.dark .sc_act,
-html.dark .su-box-content,
 html.dark blockquote {
-  background: var(--darkhx-l5);
-  color: var(--darkhx-l7);
+  background: var(--darkhx-l0);
+  color: var(--darkhx-l8);
 }
 
 html.dark .sc_act:hover {
-  background: #8b8b8b;
+  background: var(--darkhx-l5);
 }
 
-/* spoiler */
-html.dark .su-spoiler-style-fancy > .su-spoiler-title {
-  background: var(--darkhx-l2);
+html.dark .navbar .nav > li > .dropdown-menu::after {
+	border-bottom: 6px solid var(--darkhx-l1);
 }
 
-html.dark .su-spoiler-content {
-  background: var(--darkhx-l4);
-  display: flex;
-  flex-direction: column;
-  gap: 10px;
+html.dark .searchform div input {
+  color: var(--darkhx-l9);
 }
 
-/* article page */
+html.dark .su-service-title,
 html.dark .entry p,
 html.dark .entry strong {
   color: var(--darkhx-l9);
+}
+
+html.dark .entry,
+html.dark .entry h1,
+html.dark .entry h2,
+html.dark .entry h3 {
+  color: var(--darkhx-l8);
 }
 
 html.dark .entry img {
@@ -140,9 +143,69 @@ html.dark .entry img {
   background: none;
 }
 
+html.dark [class*="markup--"] {
+  color: var(--darkhx-l7) !important;
+}
+
+html.dark .entry th {
+  background: var(--darkhx-l2);
+}
+
+html.dark .su-spoiler-style-fancy > .su-spoiler-title {
+  background: var(--darkhx-l2);
+}
+
+html.dark .su-spoiler-content {
+  background: var(--darkhx-l0);
+}
+
+html.dark .su-box-content {
+  background: var(--darkhx-l0);
+  color: var(--darkhx-l9);
+}
+
+
+html.dark .entry .wp-caption {
+  background: var(--darkhx-l2);
+}
+
 html.dark .dlbox .dlbox-title {
   color: var(--darkhx-l8);
   background: var(--darkhx-l2);
+}
+
+html.dark .dlbox p.dlbox-links a[href*="pan.baidu.com/s/"] {
+  color: var(--darkhx-l3);
+  filter: invert(100%);
+}
+
+html.dark .quicktags-toolbar input{
+  color: var(--darkhx-l8);
+  background: var(--darkhx-l1);
+  border-radius: 2px;
+}
+
+html.dark .quicktags-toolbar input:hover {
+  color: var(--darkhx-l9) !important;
+  background: var(--darkhx-l5);
+}
+
+html.dark .aplayer {
+  background: var(--darkhx-l0);
+}
+
+html.dark .aplayer .aplayer-lrc::before,
+html.dark .aplayer .aplayer-lrc::after {
+  background: linear-gradient(180deg,hsla(0,0%,0%,0) 0, hsla(0,0%,0%,.8));
+}
+
+html.dark .aplayer .aplayer-info .aplayer-controller .aplayer-bar-wrap .aplayer-bar {
+  background: var(--darkhx-l3) !important;
+}
+
+
+html.dark .commentlist a:hover {
+  color: var(--darkhx-accent-0);
 }
 
 html.dark #author-box h3,
@@ -166,10 +229,75 @@ html.dark #user-menu li {
   background: var(--darkhx-l1) !important;
 }
 
+html.dark textarea#comment {
+  font-weight: 600;
+}
+
 html.dark #commentform textarea,
 html.dark #submit-bt {
   -webkit-text-fill-color: var(--darkhx-l7);
 }
+
+html.dark #user-menu a,
+html.dark .user-avatar p {
+  color: var(--darkhx-l9);
+}
+
+html.dark #user-menu a:hover {
+  color: var(--darkhx-accent-0);
+}
+
+html.dark #fep-menu .fep-button, .fep-button-active {
+  background: var(--darkhx-l1);
+  color: var(--darkhx-l8) !important;
+}
+
+html.dark #fep-menu .fep-button, .fep-button-active:hover,
+html.dark #fep-menu .fep-button, .fep-button-active:active {
+  background: var(--darkhx-l2) !important;
+}
+
+html.dark .footer-nav ul {
+  background: var(--darkhx-l2);
+  transition: background 0.2s ease-out;
+}
+
+html.dark .footer-nav ul:hover {
+  background: var(--darkhx-accent-0);
+  transition: background 0.1s ease-in;
+}
+
+html.dark #ranking-item select {
+  background: var(--darkhx-l0);
+  color: var(--darkhx-l9);
+}
+
+html.dark [color="#351755"],
+html.dark [style*='color:#351755'],
+html.dark [style*='color: #351755']{
+  color: #6e40a0 !important;
+}
+
+html.dark [color="#3812b1"],
+html.dark [style*='color:#3812b1'],
+html.dark [style*='color: #3812b1']{
+  color: #552ade !important;
+}
+
+html.dark [color="#000080"],
+html.dark [style*='color:#000080'],
+html.dark [style*='color: #000080']{
+  color: #164cff !important;
+}
+
+html.dark .logoimg {
+  scale: 83%;
+}
+
+html.dark div[id^="barrage_"] {
+  z-index: 99;
+}
+
 
 `)
 


### PR DESCRIPTION
### Sorry for my mega pr
---
- As the title says, instead of grey, the tune is way darker now;
- As the title says, filled more webpage elements with darkness energy;
- As the title says, fixed two bugs from original stylesheet I guess?
- Replaced some low-visible colours to a lighten one for example: #000080, #3812b1, #351755.

---
And happy ***Chinese New Year***, yaa.